### PR TITLE
Use auto-doc's commit SHA as revision

### DIFF
--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -15,7 +15,8 @@ jobs:
           fetch-depth: 0
 
       - name: 'run auto-doc'
-        uses: tj-actions/auto-doc@v3
+        # v3.5.0
+        uses: tj-actions/auto-doc@79cbc18cd7c4b037bb2fe25199cb14fef4bbad43
         with:
           filename: 'action.yml'
           output: 'README.md'


### PR DESCRIPTION
This is a supply-chain security improvement. Commit SHAs are less malleable than tags.