### PR TITLE
Rename action field `persist_dir`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           # Not setting release_name to test the default behavior
           release_type: 'file'
-          persist_dir: '/tmp/persist'
           artifacts_dir: 'artifacts'
+          persist_dir_on_device: '/tmp/persist'
           base_install_path_on_device: '/tmp/ota'
           project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'
@@ -64,8 +64,8 @@ jobs:
         with:
           release_name: 'archive-release ${{ env.TIMESTAMP }}'
           release_type: 'zip_archive'
-          persist_dir: '/tmp/persist'
           zip_archive_dir: 'artifacts'
+          persist_dir_on_device: '/tmp/persist'
           base_install_path_on_device: '/tmp/ota'
           project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'
@@ -93,8 +93,8 @@ jobs:
         with:
           release_name: 'rootfs-release ${{ env.TIMESTAMP }}'
           release_type: 'rootfs'
-          persist_dir: '/tmp/persist'
           rootfs_img_path: 'rootfs.img'
+          persist_dir_on_device: '/tmp/persist'
           project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'
           signing_key: ${{ secrets.TEST_SIGNING_KEY }}

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ jobs:
         with:
           release_name: 'OPTIONAL RELEASE NAME'
           release_type: 'file'
-          persist_dir: '/tmp/persist'
           artifacts_dir: 'artifacts'
+          persist_dir_on_device: '/tmp/persist'
           base_install_path_on_device: '/tmp/ota'
           project_access_token: ${{ secrets.PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'
@@ -75,8 +75,8 @@ the "OTA Release" step as
         with:
           release_name: 'OPTIONAL RELEASE NAME'
           release_type: 'rootfs'
-          persist_dir: '/tmp/persist'
           rootfs_img_path: '/path/to/rootfs.img'
+          persist_dir_on_device: '/tmp/persist'
           project_access_token: ${{ secrets.PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'
           signing_key: ${{ secrets.SIGNING_KEY }}
@@ -91,8 +91,8 @@ For zip archive update, configure the "OTA Release" step as
         with:
           release_name: 'OPTIONAL RELEASE NAME'
           release_type: 'zip_archive'
-          persist_dir: '/tmp/persist'
           zip_archive_dir: '/path/to/uncompressed_artifacts_dir'
+          persist_dir_on_device: '/tmp/persist'
           base_install_path_on_device: '/tmp/ota'
           project_access_token: ${{ secrets.PROJECT_ACCESS_TOKEN }}
           signing_key_management: 'local'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Release type ("file", "zip_archive", or "rootfs")'
     required: true
     default: 'file'
-  persist_dir:
+  persist_dir_on_device:
     description: 'Path to the directory where the device can persist data'
     required: true
     default: ''

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@
 #
 # INPUT_RELEASE_NAME
 # INPUT_RELEASE_TYPE
-# INPUT_PERSIST_DIR
+# INPUT_PERSIST_DIR_ON_DEVICE
 # INPUT_ARTIFACTS_DIR
 # INPUT_ROOTFS_IMG_PATH
 # INPUT_ZIP_ARCHIVE_DIR
@@ -49,9 +49,12 @@ download_trh() {
 
 get_manifest_template_hack() {
   # Hack alert: Need to do this to get a manifest template
+  local persist_dir="${INPUT_PERSIST_DIR_ON_DEVICE:-}"
+  [ -z "${persist_dir}" ] && err "No persist directory provided"
+
   mkdir -p "$(dirname "${THISTLE_KEY}")"
   echo "${INPUT_SIGNING_KEY}" > "${THISTLE_KEY}"
-  "${TRH_BINARY_PATH}" init --persist="${INPUT_PERSIST_DIR}" > /dev/null
+  "${TRH_BINARY_PATH}" init --persist="${persist_dir}" > /dev/null
 }
 
 file_release() {


### PR DESCRIPTION
Rename `persist_dir` to `persist_dir_on_device`, to signify that this refers to a path on the device side.

In general, we will use the convention of `_on_device` suffix to indicate device-side config items, e.g., `base_install_path_on_device`.