### PR TITLE
Support remote signing key management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   test_ota_release_file:
-    name: 'Test OTA Release Action (release_type: file)'
+    name: 'Test OTA Release Action (release_type: file, signing_key_management: local)'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@v4'
-    
+
       - name: 'Create artifacts for test'
         run: |
           mkdir -p artifacts
@@ -38,9 +38,37 @@ jobs:
           signing_key: ${{ secrets.TEST_SIGNING_KEY }}
           signing_key_password: ${{ secrets.TEST_SIGNING_KEY_PASSWORD }}
 
-  test_ota_release_zip_archive:
-    name: 'Test OTA Release Action (release_type: zip_archive)'
+  test_ota_release_file_remote_signing:
     needs: 'test_ota_release_file'
+    name: 'Test OTA Release Action (release_type: file, signing_key_management: remote)'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Create artifacts for test'
+        run: |
+          mkdir -p artifacts
+          hello_time="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+          echo "${hello_time}: Hello, World!" > artifacts/hello.txt
+          sleep 4.2
+          goodbye_time="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+          echo "${goodbye_time}: Goodbye, World!" > artifacts/goodbye.txt
+
+      - name: 'Test OTA Release'
+        uses: './' # Use an action in the root directory
+        with:
+          # Not setting release_name to test the default behavior
+          release_type: 'file'
+          artifacts_dir: 'artifacts'
+          persist_dir_on_device: '/tmp/persist'
+          base_install_path_on_device: '/tmp/ota'
+          project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
+          signing_key_management: 'remote'
+
+  test_ota_release_zip_archive:
+    needs: 'test_ota_release_file_remote_signing'
+    name: 'Test OTA Release Action (release_type: zip_archive, signing_key_management: local)'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -72,9 +100,41 @@ jobs:
           signing_key: ${{ secrets.TEST_SIGNING_KEY }}
           signing_key_password: ${{ secrets.TEST_SIGNING_KEY_PASSWORD }}
 
-  test_ota_release_rootfs:
-    name: 'Test OTA Release Action (release_type: rootfs)'
+  test_ota_release_zip_archive_remote_signing:
     needs: 'test_ota_release_zip_archive'
+    name: 'Test OTA Release Action (release_type: zip_archive, signing_key_management: remote)'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Set up environment'
+        run: |
+          echo "TIMESTAMP=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> $GITHUB_ENV
+
+      - name: 'Create artifacts for test'
+        run: |
+          mkdir -p artifacts
+          hello_time="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+          echo "${hello_time}: Hello, World!" > artifacts/hello.txt
+          sleep 4.2
+          goodbye_time="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+          echo "${goodbye_time}: Goodbye, World!" > artifacts/goodbye.txt
+
+      - name: 'Test OTA Release'
+        uses: './' # Use an action in the root directory
+        with:
+          release_name: 'archive-release ${{ env.TIMESTAMP }}'
+          release_type: 'zip_archive'
+          zip_archive_dir: 'artifacts'
+          persist_dir_on_device: '/tmp/persist'
+          base_install_path_on_device: '/tmp/ota'
+          project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
+          signing_key_management: 'remote'
+
+  test_ota_release_rootfs:
+    needs: 'test_ota_release_zip_archive_remote_signing'
+    name: 'Test OTA Release Action (release_type: rootfs, signing_key_management: local)'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -99,3 +159,29 @@ jobs:
           signing_key_management: 'local'
           signing_key: ${{ secrets.TEST_SIGNING_KEY }}
           signing_key_password: ${{ secrets.TEST_SIGNING_KEY_PASSWORD }}
+
+  test_ota_release_rootfs_remote_signing:
+    needs: 'test_ota_release_rootfs'
+    name: 'Test OTA Release Action (release_type: rootfs, signing_key_management: remote)'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Set up environment'
+        run: |
+          echo "TIMESTAMP=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> $GITHUB_ENV
+
+      - name: 'Create (bogus) rootfs for test'
+        run: |
+          echo "Create fake rootfs at ${{ env.TIMESTAMP }}" > rootfs.img
+
+      - name: 'Test OTA Release'
+        uses: './' # Use an action in the root directory
+        with:
+          release_name: 'rootfs-release ${{ env.TIMESTAMP }}'
+          release_type: 'rootfs'
+          rootfs_img_path: 'rootfs.img'
+          persist_dir_on_device: '/tmp/persist'
+          project_access_token: ${{ secrets.TEST_PROJECT_ACCESS_TOKEN }}
+          signing_key_management: 'remote'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,10 +87,10 @@ file_release() {
   local base_install_path="${INPUT_BASE_INSTALL_PATH_ON_DEVICE:-}"
   [ -z "${base_install_path}" ] && err "No base install path provided"
 
-  eval "${TRH_COMMAND}" prepare --target="${artifacts_dir}" --file-base-path="${base_install_path}"
+  eval "${TRH_COMMAND}" prepare --target="\"${artifacts_dir}\"" --file-base-path="\"${base_install_path}\""
 
   if [ -n "${release_name}" ]; then
-    eval "${TRH_COMMAND}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="\"${release_name}\""
   else
     eval "${TRH_COMMAND}" release
   fi 
@@ -106,10 +106,10 @@ rootfs_release() {
   local rootfs_img_path="${INPUT_ROOTFS_IMG_PATH:-}"
   [ -z "${rootfs_img_path}" ] && err "No rootfs image path provided"
 
-  eval "${TRH_COMMAND}" prepare --target="${rootfs_img_path}"
+  eval "${TRH_COMMAND}" prepare --target="\"${rootfs_img_path}\""
 
   if [ -n "${release_name}" ]; then
-    eval "${TRH_COMMAND}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="\"${release_name}\""
   else
     eval "${TRH_COMMAND}" release
   fi
@@ -128,10 +128,10 @@ zip_archive_release() {
   local base_install_path="${INPUT_BASE_INSTALL_PATH_ON_DEVICE:-}"
   [ -z "${base_install_path}" ] && err "No base install path provided"
 
-  eval "${TRH_COMMAND}" prepare --zip-target --target="${zip_archive_dir}" --file-base-path="${base_install_path}"
+  eval "${TRH_COMMAND}" prepare --zip-target --target="\"${zip_archive_dir}\"" --file-base-path="\"${base_install_path}\""
 
   if [ -n "${release_name}" ]; then
-    eval "${TRH_COMMAND}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="\"${release_name}\""
   else
     eval "${TRH_COMMAND}" release
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,15 +28,29 @@ SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
 TRH_BINARY_PATH="${SCRIPT_DIR}/trh"
 readonly TRH_BINARY_PATH
-TRH_DOWNLOAD_URL="https://downloads.thistle.tech/embedded-client/1.1.0/trh-1.1.0-x86_64-unknown-linux-musl.gz"
+TRH_DOWNLOAD_URL="https://downloads.thistle.tech/embedded-client/1.2.1/trh-1.2.1-x86_64-unknown-linux-musl.gz"
 readonly TRH_DOWNLOAD_URL
 
 # Set environment variables
-export THISTLE_KEY="${HOME}/.minisign/minisign.key"
-export THISTLE_KEY_PASS="${INPUT_SIGNING_KEY_PASSWORD}"
 export THISTLE_TOKEN="${INPUT_PROJECT_ACCESS_TOKEN}"
+
+[ -z "${INPUT_SIGNING_KEY_MANAGEMENT}" ] && err "No signing key management provided"
+[ "${INPUT_SIGNING_KEY_MANAGEMENT}" = "local" ] || [ "${INPUT_SIGNING_KEY_MANAGEMENT}" = "remote" ] || {
+  err "Unknown signing key management: ${INPUT_SIGNING_KEY_MANAGEMENT}"
+}
+
+[ "${INPUT_SIGNING_KEY_MANAGEMENT}" = "local" ] && {
+  export THISTLE_KEY="${HOME}/.minisign/minisign.key"
+  export THISTLE_KEY_PASS="${INPUT_SIGNING_KEY_PASSWORD}"
+}
+
 [ -z "${INPUT_BACKEND_URL}" ] || export THISTLE_BACKEND="${INPUT_BACKEND_URL}"
 
+# Set TRH command based on signing method
+TRH_COMMAND="${TRH_BINARY_PATH} --signing-method=${INPUT_SIGNING_KEY_MANAGEMENT}"
+readonly TRH_COMMAND
+
+# Functions
 err() {
   echo -e "$*"
   exit 1
@@ -54,9 +68,12 @@ get_manifest_template_hack() {
   local persist_dir="${INPUT_PERSIST_DIR_ON_DEVICE:-}"
   [ -z "${persist_dir}" ] && err "No persist directory provided"
 
-  mkdir -p "$(dirname "${THISTLE_KEY}")"
-  echo "${INPUT_SIGNING_KEY}" > "${THISTLE_KEY}"
-  "${TRH_BINARY_PATH}" init --persist="${persist_dir}" > /dev/null
+  if [ "${INPUT_SIGNING_KEY_MANAGEMENT}" = "local" ]; then
+    mkdir -p "$(dirname "${THISTLE_KEY}")"
+    echo "${INPUT_SIGNING_KEY}" > "${THISTLE_KEY}"
+  fi
+
+  eval "${TRH_COMMAND}" init --persist="${persist_dir}" > /dev/null
 }
 
 file_release() {
@@ -70,12 +87,12 @@ file_release() {
   local base_install_path="${INPUT_BASE_INSTALL_PATH_ON_DEVICE:-}"
   [ -z "${base_install_path}" ] && err "No base install path provided"
 
-  "${TRH_BINARY_PATH}" prepare --target="${artifacts_dir}" --file-base-path="${base_install_path}"
+  eval "${TRH_COMMAND}" prepare --target="${artifacts_dir}" --file-base-path="${base_install_path}"
 
   if [ -n "${release_name}" ]; then
-    "${TRH_BINARY_PATH}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="${release_name}"
   else
-    "${TRH_BINARY_PATH}" release
+    eval "${TRH_COMMAND}" release
   fi 
 
   echo "done"
@@ -89,12 +106,12 @@ rootfs_release() {
   local rootfs_img_path="${INPUT_ROOTFS_IMG_PATH:-}"
   [ -z "${rootfs_img_path}" ] && err "No rootfs image path provided"
 
-  "${TRH_BINARY_PATH}" prepare --target="${rootfs_img_path}"
+  eval "${TRH_COMMAND}" prepare --target="${rootfs_img_path}"
 
   if [ -n "${release_name}" ]; then
-    "${TRH_BINARY_PATH}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="${release_name}"
   else
-    "${TRH_BINARY_PATH}" release
+    eval "${TRH_COMMAND}" release
   fi
 
   echo "done"
@@ -111,12 +128,12 @@ zip_archive_release() {
   local base_install_path="${INPUT_BASE_INSTALL_PATH_ON_DEVICE:-}"
   [ -z "${base_install_path}" ] && err "No base install path provided"
 
-  "${TRH_BINARY_PATH}" prepare --zip-target --target="${zip_archive_dir}" --file-base-path="${base_install_path}"
+  eval "${TRH_COMMAND}" prepare --zip-target --target="${zip_archive_dir}" --file-base-path="${base_install_path}"
 
   if [ -n "${release_name}" ]; then
-    "${TRH_BINARY_PATH}" release --name="${release_name}"
+    eval "${TRH_COMMAND}" release --name="${release_name}"
   else
-    "${TRH_BINARY_PATH}" release
+    eval "${TRH_COMMAND}" release
   fi
 
   echo "done"


### PR DESCRIPTION
Add support of remote signing with Cloud KMS managed OTA signing keys. This feature is supported in trh v1.2.1.